### PR TITLE
Add utility to pull shared configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
 # Spyro
+
 A Chrome extension for working with a combination of JIRA and Splunk to create event types that correspond to JIRAs.
 
 ## Foundational Design Choices
+
 This project is created with the following fundamental design choices:
 
 ### Shared Configuration
+
 A single shared configuration, meaning everyone is always logging issues and creating event types consistently with others using the same configuration.
 
 ### Simple
-When creating events and issues, the only thing that someone should have to think about is the Splunk search that defines the event type (as this is the part that generally requires a person's participation).  
+
+When creating events and issues, the only thing that someone should have to think about is the Splunk search that defines the event type (as this is the part that generally requires a person's participation).
 
 ### Guided
-The process should be guided.  Ensure that when logging issues, the person logging issues is guided through the right steps required to be compliant with process.
+
+The process should be guided. Ensure that when logging issues, the person logging issues is guided through the right steps required to be compliant with process.
 
 ### Configurable
-Process and practices change.  The steps taken to log issues should be externalized into configuration to ensure that it can change in the future.
+
+Process and practices change. The steps taken to log issues should be externalized into configuration to ensure that it can change in the future.
 
 ## Development
+
 If you are interested in developing on this project, see the [Developing](./Developing) documentation for more information.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "format": "prettier ./src/**/*.js --write"
+    "format": "prettier ./src/**/*.{js,json} --write"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/tests/testdata/SampleSettings.json
+++ b/src/tests/testdata/SampleSettings.json
@@ -1,0 +1,54 @@
+{
+  "shared": {
+    "splunk": {
+      "instances": [
+        {
+          "key": "splunk1",
+          "url": "http://splunk.com",
+          "apiUrl": "http://splunk.com/api"
+        },
+        {
+          "key": "splunk2",
+          "url": "http://splunk2.com",
+          "apiUrl": "http://splunk2.com/api"
+        }
+      ]
+    },
+    "jira": {
+      "instances": [
+        {
+          "key": "jira1",
+          "issueUrl": "https://jira1.com/browse/",
+          "restApiUrl": "https://jira1.com/rest/api/latest"
+        },
+        {
+          "key": "jira2",
+          "issueUrl": "https://jira2.com/browse/",
+          "restApiUrl": "https://jira2.com/rest/api/latest"
+        }
+      ]
+    }
+  },
+  "issueTemplates": [
+    {
+      "name": "Team 1 Prod Issue",
+      "jiraInstance": "jira1",
+      "splunkInstance": "splunk2",
+      "fieldValues": {
+        "project": "MAVEN",
+        "customfield_1234": "1234",
+        "customfield_456": "5292"
+      }
+    },
+    {
+      "name": "Team 2 Prod Issue",
+      "jiraInstance": "jira2",
+      "splunkInstance": "splunk1",
+      "fieldValues": {
+        "project": "MAVEN3",
+        "customfield_988": "asdf",
+        "customfield_456": "5292"
+      }
+    }
+  ]
+}

--- a/src/tests/utils/SettingsUtility.js
+++ b/src/tests/utils/SettingsUtility.js
@@ -1,0 +1,16 @@
+import SettingsUtility from '../../utils/SettingsUtility';
+import sampleSettings from '../testdata/SampleSettings';
+
+describe('SettingsUtility', () => {
+  it('successfully retrieves the Jira settings for the provided key', () => {
+    const expectedInstance = sampleSettings.shared.jira.instances[1];
+    const actualInstance = SettingsUtility.getJiraInstanceByKey(sampleSettings, 'jira2');
+    expect(actualInstance).toBe(expectedInstance);
+  });
+
+  it('successfully retrieves the Splunk settings for the provided key', () => {
+    const expectedInstance = sampleSettings.shared.splunk.instances[1];
+    const actualInstance = SettingsUtility.getSplunkInstanceByKey(sampleSettings, 'splunk2');
+    expect(actualInstance).toEqual(expectedInstance);
+  });
+});

--- a/src/utils/SettingsUtility.js
+++ b/src/utils/SettingsUtility.js
@@ -1,0 +1,60 @@
+function checkIfThereAreInstances(typeOfInstance, settings) {
+  return (
+    settings &&
+    settings.shared &&
+    settings.shared[typeOfInstance].instances &&
+    settings.shared[typeOfInstance].instances.length > 0
+  );
+}
+
+function findInstance(typeOfInstance, key, settings) {
+  const matchingInstance = settings.shared[typeOfInstance].instances.find((instance) => instance.key === key);
+  if (matchingInstance) {
+    return matchingInstance;
+  }
+
+  return {};
+}
+
+/**
+ * Utilities to improve the consumption of settings data.
+ */
+const SettingsUtility = {
+  /**
+   * Retrieves the Jira instance associated with the key.
+   *
+   * @param {Object} settings
+   *    The settings of the extension.
+   * @param {String} instanceKey
+   *    A string for the Jira instance to retrieve.
+   * @returns {Object} The data for the Jira instance associated to the key provided. If no data is found, an empty
+   *                   object is returned.
+   */
+  getJiraInstanceByKey: (settings, instanceKey) => {
+    if (checkIfThereAreInstances('jira', settings)) {
+      return findInstance('jira', instanceKey, settings);
+    }
+
+    return {};
+  },
+
+  /**
+   * Retrieves the Splunk instance associated with the key.
+   *
+   * @param {Object} settings
+   *    The settings of the extension.
+   * @param {String} instanceKey
+   *    A string for the Splunk instance to retrieve.
+   * @returns {Object} The data for the Splunk instance associated to the key provided. If no data is found, an empty
+   *                   object is returned.
+   */
+  getSplunkInstanceByKey: (settings, instanceKey) => {
+    if (checkIfThereAreInstances('splunk', settings)) {
+      return findInstance('splunk', instanceKey, settings);
+    }
+
+    return {};
+  },
+};
+
+export default SettingsUtility;


### PR DESCRIPTION
Adds a convenience utility for getting a Splunk / Jira instance by a key.

API
```
// How someone might get the settings in a React component
import { SettingsContext } from './SettingsContext';
const settings = useContext(SettingsContext);

// The actual API
const splunkData = SettingsUtility.getSplunkInstanceByKey(settings, 'splunk2');
```

Notes
* Seems like some README.md formatting was needed by Prettier, so adding them here.
* Went ahead and added a test for this. We don't have a split between main and test so I was thinking of adding a "main" hierarchy in the next PR.