### PR TITLE
Add issue template selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,6 +1221,17 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.27.tgz",
+      "integrity": "sha512-Nl2F4bCws10BGWFJalAJZ9/qEGpxhUWvIGBye1KIeqfesRqc6A/L799sMbPSgXviasVD8s1RrstOKcyKI0A0Ew==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.4.0",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.4.1.tgz",
@@ -6174,9 +6185,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
+      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.4.1",
+    "@material-ui/lab": "^4.0.0-alpha.27",
     "@material-ui/styles": "^4.4.1",
     "axios": "^0.19.0",
     "prop-types": "^15.7.2",

--- a/src/main/components/Popup.js
+++ b/src/main/components/Popup.js
@@ -24,6 +24,10 @@ const useStyles = makeStyles((theme) => ({
     width: 'auto',
     marginBottom: theme.spacing(2),
   },
+  mainContainer: {
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+  },
 }));
 
 function Popup() {
@@ -57,7 +61,7 @@ function Popup() {
             }
 
             return (
-              <>
+              <div className={classes.mainContainer}>
                 <TemplateSelector
                   issueTemplates={settings.issueTemplates}
                   indexOfSelectedTemplate={indexOfSelectedTemplate}
@@ -66,7 +70,7 @@ function Popup() {
                 {settings && settings.issueTemplates && settings.issueTemplates.length > 0 && (
                   <pre>{JSON.stringify(settings.issueTemplates[indexOfSelectedTemplate], null, 2)}</pre>
                 )}
-              </>
+              </div>
             );
           }}
         </SettingsContextProvider>

--- a/src/main/components/TemplateSelector.js
+++ b/src/main/components/TemplateSelector.js
@@ -1,32 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FormControl from '@material-ui/core/FormControl';
-import MenuItem from '@material-ui/core/MenuItem';
-import InputLabel from '@material-ui/core/InputLabel';
-import Select from '@material-ui/core/Select';
 import Box from '@material-ui/core/Box';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 
 const TemplateSelector = (props) => {
   const { issueTemplates, indexOfSelectedTemplate, onSelectionChange } = props;
 
-  const onSelectChange = (event) => {
-    const { value } = event.target;
-    onSelectionChange(value);
+  const onSelectChange = (event, newValue) => {
+    onSelectionChange(newValue);
   };
 
   return (
     <>
       <Box>
         <FormControl fullWidth>
-          <InputLabel htmlFor="jira-template-select">Jira Template</InputLabel>
-          <Select value={indexOfSelectedTemplate} onChange={onSelectChange} id="jira-template-select">
+          <ToggleButtonGroup
+            exclusive
+            size="small"
+            value={indexOfSelectedTemplate}
+            onChange={onSelectChange}
+            id="jira-template-select"
+          >
             {issueTemplates.map((issueTemplate, index) => (
               // eslint-disable-next-line react/no-array-index-key
-              <MenuItem key={index} value={index}>
+              <ToggleButton key={index} value={index}>
                 {issueTemplate.name}
-              </MenuItem>
+              </ToggleButton>
             ))}
-          </Select>
+          </ToggleButtonGroup>
         </FormControl>
       </Box>
     </>


### PR DESCRIPTION
Addresses #17 

Added a control for selecting the issue template. The description of #17 originally referenced a button group but since the names are configured by the user, I figured having a dropdown that could span the full width of the popup would be a low-cost way of handling long names.

![image](https://user-images.githubusercontent.com/5365325/65645978-24c2bb00-dfbf-11e9-954e-6a25644d4ab9.png)


![image](https://user-images.githubusercontent.com/5365325/65696425-cf2df300-e03e-11e9-9680-a1151d30b2ab.png)

![image](https://user-images.githubusercontent.com/5365325/65696454-dbb24b80-e03e-11e9-9a93-900091473a8a.png)
