### PR TITLE
Pull Splunk app from template

### DIFF
--- a/src/main/components/Popup.js
+++ b/src/main/components/Popup.js
@@ -50,15 +50,13 @@ function Popup() {
 
   async function loadJobDetailsFromURL(selectedTemplate, applicationSettings) {
     getCurrentSplunkUrl().then(async (url) => {
-      const { splunkInstance } = selectedTemplate;
+      const { splunkInstance, splunkApp } = selectedTemplate;
       Credentials.getEntryByKey(splunkInstance).then((credential) => {
         const splunkAPIURL = getSplunkRestUrl(applicationSettings.shared.splunk.instances, splunkInstance);
 
         if (!splunkAPIURL) {
           return Promise.reject(new Error('No Splunk API URL specified'));
         }
-
-        const splunkApp = '';
 
         return SplunkJobLoader.loadJobDetailsFromURL(url, splunkAPIURL, splunkApp, credential)
           .then((response) => {


### PR DESCRIPTION
Small change but wasn't clear originally on where Splunk app was coming from.

Assumes these structures and keys

```
  "issueTemplates": [
    {
      "name": "Prod Issue",
      "jiraInstance": "jira1",
      "splunkInstance": "splunk2",
      "splunkApp": "splunk_app",
      "fieldValues": {}
    },
  ]
```